### PR TITLE
Support marked text

### DIFF
--- a/lib/block-list.js
+++ b/lib/block-list.js
@@ -6,7 +6,7 @@ import Embed from './components/embed';
 function renderItem (item) {
   if (item.type === 'paragraph') {
     const hasContent = item.children.filter(item => item.type !== 'linebreak' &&
-        item.content && item.content.trim()).length > 0;
+        (item.content && item.content.trim()) || item.mark).length > 0;
 
     if (!hasContent) {
       return '';

--- a/lib/text.js
+++ b/lib/text.js
@@ -1,5 +1,10 @@
 import { element } from 'deku';
 
+function wrapMark (node, el) {
+  const markClass = node.markClass || null;
+  return node.mark ? <mark class={markClass}>{el}</mark> : el;
+}
+
 function wrapHref (node, el) {
   return node.href ? <a href={node.href}>{el}</a> : el;
 }
@@ -14,8 +19,8 @@ function wrapItalic (node, el) {
 
 function renderItem (item) {
   if (item.type === 'text') {
-    return wrapHref(item, wrapBold(item,
-      wrapItalic(item, String(item.content || ''))));
+    return wrapMark(item, wrapHref(item, wrapBold(item,
+      wrapItalic(item, String(item.content || '')))));
   }
 
   if (item.type === 'linebreak') {

--- a/test/index.js
+++ b/test/index.js
@@ -10,12 +10,19 @@ test('paragraphs', t => {
       { type: 'linebreak' },
       { type: 'text', content: 'normal text' },
       { type: 'text', bold: true, content: 'bold text' },
-      { type: 'text', italic: true, content: 'italic text' }
+      { type: 'text', italic: true, content: 'italic text' },
+      { type: 'text', mark: true, content: 'marked text' },
+      { type: 'text', mark: true, markClass: 'marker1' }
     ]
   }, {
     type: 'paragraph',
     children: [
       { type: 'text', content: 'other text' }
+    ]
+  }, {
+    type: 'paragraph',
+    children: [
+      { type: 'text', mark: true }
     ]
   }];
 
@@ -25,8 +32,11 @@ test('paragraphs', t => {
         <a href="http://mic.com">link</a>
         <br/>
         normal text<b>bold text</b><i>italic text</i>
+        <mark>marked text</mark>
+        <mark class="marker1"></mark>
       </p>
       <p>other text</p>
+      <p><mark></mark></p>
     </article>`
   );
 });


### PR DESCRIPTION
R = @kesla 

Extended text node with new `mark` and `markClass` properties that allows to highlight some part of the article or add any marker in between the text.