### PR TITLE
switch to deku 1 and magic virtual element 1

### DIFF
--- a/lib/embeds.js
+++ b/lib/embeds.js
@@ -1,4 +1,4 @@
-import { element } from 'deku';
+import element from 'magic-virtual-element';
 
 function renderImage (props) {
   const width = props.width || 0;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,9 @@
-import { string, element } from 'deku';
+import { renderString, tree } from 'deku';
+import element from 'magic-virtual-element';
 import setupArticle from 'article-json-html-render';
 import embeds from './embeds';
 
 const Article = setupArticle({ embeds });
 
-module.exports = items => string.render(<Article items={items || []} />)
+module.exports = items => renderString(tree(<Article items={items || []} />))
   .replace(/<br><\/br>/g, '<br/>'); // fix double br bug

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "tsml": "^1.0.1"
   },
   "dependencies": {
-    "article-json-html-render": "^1.0.0",
-    "deku": "^2.0.0-rc15"
+    "article-json-html-render": "^2.0.0",
+    "deku": "^1.0.0",
+    "magic-virtual-element": "^1.0.6"
   }
 }


### PR DESCRIPTION
Bumping https://github.com/micnews/article-json-html-render to latest version, needs deku@1 and magic-virtual-element@1

R = @kesla 
T = Patch