### PR TITLE
Added basic tumblr post support - renders as a text link

### DIFF
--- a/lib/embeds.js
+++ b/lib/embeds.js
@@ -106,6 +106,14 @@ function renderCustom (props) {
   return '';
 }
 
+function renderTumblr (props) {
+  const { url, text } = props;
+  const href = text[0] && text[0].href ? text[0].href : url;
+
+  // There is no other way to show tumblr posts currently
+  return <a target='_blank' class='tumblr-post' href={href}>Load Tumblr post in new window</a>;
+}
+
 const types = {
   image: renderImage,
   youtube: renderYoutube,
@@ -114,6 +122,7 @@ const types = {
   vine: renderVine,
   instagram: renderInstagram,
   spotify: renderSpotify,
+  tumblr: renderTumblr,
   custom: renderCustom
 };
 

--- a/lib/embeds.js
+++ b/lib/embeds.js
@@ -111,7 +111,7 @@ function renderTumblr (props) {
   const href = text[0] && text[0].href ? text[0].href : url;
 
   // There is no other way to show tumblr posts currently
-  return <a target='_blank' class='tumblr-post' href={href}>Load Tumblr post in new window</a>;
+  return <a target='_blank' class='tumblr-post' href={href}>{href}</a>;
 }
 
 const types = {

--- a/test/index.js
+++ b/test/index.js
@@ -144,10 +144,10 @@ test('embeds', t => {
         <amp-iframe width="auto" height="80" layout="fixed-height" frameborder="0" src="https://embed.spotify.com/?uri=spotify:user:spotify:playlist:3rgsDhGHZxZ9sB9DQWQfuf"></amp-iframe>
       </figure>
       <figure>
-        <a target="_blank" class="tumblr-post" href="http://jencita.tumblr.com/post/147291233392/tswiftdaily-taylor-swift-at-lady-cilento">Load Tumblr post in new window</a>
+        <a target="_blank" class="tumblr-post" href="http://jencita.tumblr.com/post/147291233392/tswiftdaily-taylor-swift-at-lady-cilento">http://jencita.tumblr.com/post/147291233392/tswiftdaily-taylor-swift-at-lady-cilento</a>
       </figure>
       <figure>
-        <a target="_blank" class="tumblr-post" href="https://embed.tumblr.com/embed/post/8_SX4ALNOf1fYyEcjq78YQ/147291233392">Load Tumblr post in new window</a>
+        <a target="_blank" class="tumblr-post" href="https://embed.tumblr.com/embed/post/8_SX4ALNOf1fYyEcjq78YQ/147291233392">https://embed.tumblr.com/embed/post/8_SX4ALNOf1fYyEcjq78YQ/147291233392</a>
       </figure>
     </article>`
   );

--- a/test/index.js
+++ b/test/index.js
@@ -109,6 +109,23 @@ test('embeds', t => {
     embedType: 'spotify',
     url: 'https://embed.spotify.com/?uri=spotify:user:spotify:playlist:3rgsDhGHZxZ9sB9DQWQfuf',
     height: 380
+  }, {
+    type: 'embed',
+    caption: [],
+    embedType: 'tumblr',
+    did: '7c08ba46cb75162284770cdee2a59365891a5e18',
+    url: 'https://embed.tumblr.com/embed/post/8_SX4ALNOf1fYyEcjq78YQ/147291233392',
+    text: [{
+      content: 'http://jencita.tumblr.com/post/147291233392/tswiftdaily-taylor-swift-at-lady-cilento',
+      href: 'http://jencita.tumblr.com/post/147291233392/tswiftdaily-taylor-swift-at-lady-cilento'
+    }]
+  }, {
+    type: 'embed',
+    caption: [],
+    embedType: 'tumblr',
+    did: '7c08ba46cb75162284770cdee2a59365891a5e18',
+    url: 'https://embed.tumblr.com/embed/post/8_SX4ALNOf1fYyEcjq78YQ/147291233392',
+    text: []
   }];
 
   t.is(toAmp(data), tsml
@@ -125,6 +142,12 @@ test('embeds', t => {
       </figure>
       <figure>
         <amp-iframe width="auto" height="80" layout="fixed-height" frameborder="0" src="https://embed.spotify.com/?uri=spotify:user:spotify:playlist:3rgsDhGHZxZ9sB9DQWQfuf"></amp-iframe>
+      </figure>
+      <figure>
+        <a target="_blank" class="tumblr-post" href="http://jencita.tumblr.com/post/147291233392/tswiftdaily-taylor-swift-at-lady-cilento">Load Tumblr post in new window</a>
+      </figure>
+      <figure>
+        <a target="_blank" class="tumblr-post" href="https://embed.tumblr.com/embed/post/8_SX4ALNOf1fYyEcjq78YQ/147291233392">Load Tumblr post in new window</a>
       </figure>
     </article>`
   );


### PR DESCRIPTION
This adds basic tumblr support to the AMP pages.

As there isn't yet a way of supporting the actual embed - this will render as a link to the tumblr post (or to the embed src as a fallback).