### PR TITLE
fixes issue where json needed to be in single quotes

### DIFF
--- a/lib/embeds.js
+++ b/lib/embeds.js
@@ -121,6 +121,7 @@ function renderTidal (props) {
 
 function renderAd (props) {
   const { width, height, network, slot, json } = props;
+  // This needs return a string literal because amp-ad needs the json attribute to be wrapped in single-quotes
   return (
     `<amp-ad width="${width}" height="${height}" type="${network}" data-slot="${slot}" json='${JSON.stringify(json)}'></amp-ad>`
   );

--- a/lib/embeds.js
+++ b/lib/embeds.js
@@ -122,14 +122,7 @@ function renderTidal (props) {
 function renderAd (props) {
   const { width, height, network, slot, json } = props;
   return (
-    <amp-ad
-      width={width}
-      height={height}
-      type={network}
-      data-slot={slot}
-      json={JSON.stringify(json)}
-    >
-    </amp-ad>
+    `<amp-ad width="${width}" height="${height}" type="${network}" data-slot="${slot}" json='${JSON.stringify(json)}'></amp-ad>`
   );
 }
 

--- a/lib/embeds.js
+++ b/lib/embeds.js
@@ -121,7 +121,7 @@ function renderTidal (props) {
 
 function renderAd (props) {
   const { width, height, network, slot, json } = props;
-  // This needs return a string literal because amp-ad needs the json attribute to be wrapped in single-quotes
+  // This needs to return a string literal because amp-ad needs the json attribute to be wrapped in single-quotes
   return (
     `<amp-ad width="${width}" height="${height}" type="${network}" data-slot="${slot}" json='${JSON.stringify(json)}'></amp-ad>`
   );

--- a/test/index.js
+++ b/test/index.js
@@ -285,18 +285,14 @@ test('ad', t => {
     width: 300,
     height: 250,
     slot: '123456/commander-keen',
-    json: {
-      targeting: {
-        aSlot: '0'
-      }
-    }
+    json: {targeting: {aSlot: '0'}}
   }];
 
   const actual = toAmp(data);
   const expected = tsml`
     <article>
       <figure>
-        <amp-ad width="300" height="250" type="doubleclick" data-slot="123456/commander-keen" json="{"targeting":{"aSlot":"0"}}"></amp-ad>
+        <amp-ad width="300" height="250" type="doubleclick" data-slot="123456/commander-keen" json='{"targeting":{"aSlot":"0"}}'></amp-ad>
       </figure>
     </article>`;
 


### PR DESCRIPTION
T: patch

Fixes an issue where amp-ads `json` attribute didn't work properly without using single quotes.