### PR TITLE
Don't hide media in tweets

### DIFF
--- a/lib/embeds.js
+++ b/lib/embeds.js
@@ -46,8 +46,7 @@ function renderTwitter (props) {
 
   return (<amp-twitter width={486} height={657}
     layout='responsive'
-    data-tweetid={id}
-    data-cards='hidden'>
+    data-tweetid={id}>
   </amp-twitter>);
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -132,6 +132,20 @@ test('embeds', t => {
     did: '7c08ba46cb75162284770cdee2a59365891a5e18',
     url: 'https://embed.tumblr.com/embed/post/8_SX4ALNOf1fYyEcjq78YQ/147291233392',
     text: []
+  }, {
+    type: 'embed',
+    embedType: 'twitter',
+    text: [
+      {content: 'GIF vs. JIF… This ', href: null},
+      {content: 'pic.twitter.com/qFAHWgdbL6', href: 'https://t.co/qFAHWgdbL6'}
+    ],
+    url: 'https://twitter.com/MattNavarra/status/684690494841028608',
+    date: 'January 6, 2016',
+    user: {
+      slug: 'MattNavarra',
+      name: 'Matt (foo) Navarra'
+    },
+    id: '684690494841028608'
   }];
 
   t.is(toAmp(data), tsml
@@ -157,6 +171,9 @@ test('embeds', t => {
       </figure>
       <figure>
         <a target="_blank" class="tumblr-post" href="https://embed.tumblr.com/embed/post/8_SX4ALNOf1fYyEcjq78YQ/147291233392">https://embed.tumblr.com/embed/post/8_SX4ALNOf1fYyEcjq78YQ/147291233392</a>
+      </figure>
+      <figure>
+        <amp-twitter width=\"486\" height=\"657\" layout=\"responsive\" data-tweetid=\"684690494841028608\"></amp-twitter>
       </figure>
     </article>`
   );


### PR DESCRIPTION
Type: major

Removes `data-cards='hidden'` from twitter embeds, so that linked media (images etc) show up in twitter embeds. 