### PR TITLE
Set sandbox props on amp iframe

### DIFF
--- a/lib/embeds.js
+++ b/lib/embeds.js
@@ -73,6 +73,7 @@ function renderSpotify (props) {
   // Spotify large embeds that include the playlist. Only
   // small (Wx80) embeds are supported for now.
   return (<amp-iframe
+    sandbox='allow-scripts allow-same-origin'
     width='auto'
     height={80}
     layout='fixed-height'
@@ -91,6 +92,7 @@ function renderCustom (props) {
 
   if (secure) {
     return (<amp-iframe
+      sandbox='allow-scripts allow-same-origin'
       width={width}
       height={height}
       layout='responsive'

--- a/test/index.js
+++ b/test/index.js
@@ -158,10 +158,10 @@ test('embeds', t => {
         <amp-img width="600" height="200" layout="responsive" src="http://example.com/image.jpg"></amp-img>
       </figure>
       <figure>
-        <amp-iframe width="auto" height="80" layout="fixed-height" frameborder="0" src="https://embed.spotify.com/?uri=spotify:user:spotify:playlist:3rgsDhGHZxZ9sB9DQWQfuf"></amp-iframe>
+        <amp-iframe sandbox="allow-scripts allow-same-origin" width="auto" height="80" layout="fixed-height" frameborder="0" src="https://embed.spotify.com/?uri=spotify:user:spotify:playlist:3rgsDhGHZxZ9sB9DQWQfuf"></amp-iframe>
       </figure>
       <figure>
-        <amp-iframe width="auto" height="80" layout="fixed-height" frameborder="0" src="https://embed.spotify.com/?uri=spotify:user:spotify:playlist:3rgsDhGHZxZ9sB9DQWQfuf"></amp-iframe>
+        <amp-iframe sandbox="allow-scripts allow-same-origin" width="auto" height="80" layout="fixed-height" frameborder="0" src="https://embed.spotify.com/?uri=spotify:user:spotify:playlist:3rgsDhGHZxZ9sB9DQWQfuf"></amp-iframe>
       </figure>
       <figure>
         <a target="_blank" class="tidal-embed" href="https://listen.tidal.com/video/123456789">https://listen.tidal.com/video/123456789</a>
@@ -254,7 +254,7 @@ test('custom secure iframe', t => {
   t.is(toAmp(data), tsml
     `<article>
       <figure>
-        <amp-iframe width="600" height="200" layout="responsive" frameborder="0" src="https://example.com/frame"></amp-iframe>
+        <amp-iframe sandbox="allow-scripts allow-same-origin" width="600" height="200" layout="responsive" frameborder="0" src="https://example.com/frame"></amp-iframe>
       </figure>
     </article>`
   );
@@ -274,7 +274,7 @@ test('custom relative-url secure iframe', t => {
   t.is(toAmp(data), tsml
     `<article>
       <figure>
-        <amp-iframe width="600" height="200" layout="responsive" frameborder="0" src="https://example.com/frame"></amp-iframe>
+        <amp-iframe sandbox="allow-scripts allow-same-origin" width="600" height="200" layout="responsive" frameborder="0" src="https://example.com/frame"></amp-iframe>
       </figure>
     </article>`
   );


### PR DESCRIPTION
All amp iframes are sandboxed by default, this allows for scripts to run inside our amp iframes!

Type: Patch