### PR TITLE
fix failed twitter embed load

### DIFF
--- a/lib/embeds.js
+++ b/lib/embeds.js
@@ -44,10 +44,12 @@ function renderFacebook (props) {
 function renderTwitter (props) {
   const { id } = props;
 
-  return (<amp-twitter width={486} height={657}
-    layout='responsive'
-    data-tweetid={id}>
-  </amp-twitter>);
+  return (
+    <amp-twitter width='auto' height={1}
+      layout='fixed-height'
+      data-tweetid={id}>
+    </amp-twitter>
+  );
 }
 
 function renderVine (props) {

--- a/test/index.js
+++ b/test/index.js
@@ -173,7 +173,7 @@ test('embeds', t => {
         <a target="_blank" class="tumblr-post" href="https://embed.tumblr.com/embed/post/8_SX4ALNOf1fYyEcjq78YQ/147291233392">https://embed.tumblr.com/embed/post/8_SX4ALNOf1fYyEcjq78YQ/147291233392</a>
       </figure>
       <figure>
-        <amp-twitter width=\"486\" height=\"657\" layout=\"responsive\" data-tweetid=\"684690494841028608\"></amp-twitter>
+        <amp-twitter width=\"auto\" height=\"1\" layout=\"fixed-height\" data-tweetid=\"684690494841028608\"></amp-twitter>
       </figure>
     </article>`
   );


### PR DESCRIPTION
Currently Twitter embeds take up an absurd amount of height when they do not load. 

This is due to https://github.com/ampproject/amphtml/issues/5682, but the suggested solution is to hard code the height and widths. Unfortunately, on a dynamic site, it is just not feasible for us to fetch and render every twitter embed happening to check their height and width.

We can take advantage of AMP a little bit here and give these items a fixed-height of 1, which makes the twitter embed take up no extra space before load, even though it still takes up space on load. A bit hacky, but the only viable solution I see to this issue for now.